### PR TITLE
Add regex support to match

### DIFF
--- a/test/unit/patient_api_test.rb
+++ b/test/unit/patient_api_test.rb
@@ -81,6 +81,7 @@ class PatientApiTest  < Test::Unit::TestCase
     assert_equal 'Colonscopy', @context.eval('patient.procedures()[0].freeTextType()')
     assert @context.eval('patient.procedures()[0].includesCodeFrom({"CPT": ["44388"]})')
     assert_equal 1, @context.eval('patient.procedures().match({"CPT": ["44388"]}).length')
+    assert_equal 1, @context.eval('patient.procedures().regex_match({"CPT": ["4438.*"]}).length')
     assert_equal 0, @context.eval('patient.procedures().match({"CPT": ["44388"]}, sampleDate).length')
     assert_equal 'SNOMED-CT', @context.eval('patient.procedures()[0].site().codeSystemName()')
     assert_equal '71854001', @context.eval('patient.procedures()[0].site().code()')


### PR DESCRIPTION
Hi,  

The Scoophealth project is following your pophealth/patientapi fork of hquery.  We need regex support in match() and are hoping our additions can be merged back into your repo so that we don't diverge any further than necessary from what you are doing.  Note there is code duplication here but it seemed the easiest way to provide support for regex matching without changing your existing code.

Thanks,
Raymond Rusk
LeadLab
University of Victoria
Victoria, BC
